### PR TITLE
Use params instead of props in App.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Switch, Route} from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 import axios from 'axios';
 import Header from './components/header/header';
 import HomePage from './pages/HomePage/HomePage';
@@ -15,9 +15,9 @@ const App = () => {
             const res = await axios('http://localhost:5000/questions');
             setQuestions(res.data.questions);
         };
-      getQuestions();
+        getQuestions();
     }, []);
-  
+
     return (
         <div className="App">
             <Header />
@@ -29,7 +29,7 @@ const App = () => {
                     <QuestionsPage questions={questions} />
                 </Route>
                 <Route path="/question/:questionName">
-                    <QuestionPage />
+                    <QuestionPage questions={questions} />
                 </Route>
             </Switch>
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,15 +28,9 @@ const App = () => {
                 <Route path="/questions">
                     <QuestionsPage questions={questions} />
                 </Route>
-                <Route path="/question/:questionName" render={
-                    (props) => {
-                        const question = questions.filter(item => item.questionName === props.match.params.questionName)[0];
-                        if (!question) {
-                            return (<h1>LOADING....</h1>)
-                        }
-                        return <QuestionPage question={question} />
-                    }
-                }></Route>
+                <Route path="/question/:questionName">
+                    <QuestionPage />
+                </Route>
             </Switch>
         </div>
     );

--- a/src/pages/QuestionPage/QuestionPage.jsx
+++ b/src/pages/QuestionPage/QuestionPage.jsx
@@ -23,15 +23,14 @@ import HomeButton from '../../assets/QuestionPage/home-button.svg';
 
 import './QuestionPage.css';
 
-const QuestionPage = () => {
-    const { question } = useParams();
+const QuestionPage = ({ questions }) => {
+    const { questionName } = useParams();
+    const question = questions.filter(item => item.questionName === questionName)[0];
     const history = useHistory();
 
     const routeChange = () => {
         history.push('/');
     };
-
-    console.log(question);
 
     const langList = [
         'Bash',

--- a/src/pages/QuestionPage/QuestionPage.jsx
+++ b/src/pages/QuestionPage/QuestionPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
 import Footer from '../../components/footer/footer';
 import Leaderboard from '../../components/leaderboard/leaderboard';
@@ -23,12 +23,15 @@ import HomeButton from '../../assets/QuestionPage/home-button.svg';
 
 import './QuestionPage.css';
 
-const QuestionPage = ({ question }) => {
+const QuestionPage = () => {
+    const { question } = useParams();
     const history = useHistory();
 
     const routeChange = () => {
         history.push('/');
     };
+
+    console.log(question);
 
     const langList = [
         'Bash',


### PR DESCRIPTION
# feature: Use params instead of props in App.jsx

- `QuestionPage` component does not need to accept props anymore, since `useParams` in the page can get the `question`. You will, however have to pass the `questions` as a prop, which can be fixed by using `redux`.