### PR TITLE
fix: Axios URL is now an environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 node_modules
+
+.env

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,1 @@
+REACT_APP_BASE_URL=http://localhost:5000

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Switch, Route } from 'react-router-dom';
-import axios from 'axios';
+
+import api from './api';
 import Header from './components/header/header';
 import HomePage from './pages/HomePage/HomePage';
 import QuestionPage from './pages/QuestionPage/QuestionPage';
@@ -11,7 +12,7 @@ const App = () => {
 
     useEffect(() => {
         const getQuestions = async () => {
-            const res = await axios('http://localhost:5000/questions');
+            const res = await api.get('/questions');
             setQuestions(res.data.questions);
         };
         getQuestions();

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export default axios.create({
+    baseURL: process.env.REACT_APP_BASE_URL,
+    responseType: 'json',
+});


### PR DESCRIPTION
# fix: Axios URL is now an environment variable

- You can use the export from `api.js` instead of Axios. This will automatically use `REACT_APP_BASE_URL` in the `.env`, which you can set to your localhost URL.